### PR TITLE
chore: add releasing yml for applications

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -1,0 +1,97 @@
+name: Release Applications Packages
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+  pull-requests: write
+  issues: read
+
+on:
+  push:
+    paths:
+      - "apps/**"
+    branches:
+      - main
+      - staging
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  get-apps:
+    name: Get Applications for releasing
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip-apps]') }}
+    outputs:
+      apps: ${{ steps.apps.outputs.result }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          # see `fetch-depth` in README: https://github.com/actions/checkout#checkout-v4,
+          # we set to `0` so the referenced commits are available for the command below
+          fetch-depth: 0
+
+      - name: Prepare Environment
+        uses: ./.github/actions/setup-env
+        timeout-minutes: 10
+
+      - name: Get Applications
+        id: apps
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const getApps = require('./scripts/get-apps-changed.js')
+            return getApps()
+        env:
+          FROM_COMMIT: HEAD~1
+          TO_COMMIT: HEAD^
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [get-apps]
+    if: ${{ needs.get-apps.outputs.apps != null }}
+    strategy:
+      matrix:
+        relativeDir: ${{ fromJson(needs.get-apps.outputs.apps) }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+        with:
+          # see `fetch-depth` in README: https://github.com/actions/checkout#checkout-v3,
+          # we set to `0` so the referenced commits are available for the command below
+          fetch-depth: 0
+
+      - name: Prepare Environment
+        uses: ./.github/actions/setup-env
+        timeout-minutes: 10
+
+      - name: Get Applications Name
+        id: app-name
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const packageInfo = require('./${{matrix.relativeDir}}/package.json')
+            return packageInfo.name
+      - name: Get is Prerelease
+        id: is-prerelease
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return "${{ github.ref }}".replace('refs/heads/', '') !== 'main'
+
+      - name: Release Application
+        uses: google-github-actions/release-please-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
+          package-name: ${{ fromJson(steps.app-name.outputs.result) }}
+          path: ${{ matrix.relativeDir }}
+          pull-request-title-pattern: "chore(${component}): release ${version}"
+          pull-request-header: "This PR was opened by the release GitHub action. When you're ready to do a release, you can merge this and the packages will be released to Github automatically."
+          include-v-in-tag: false
+          tag-separator: "@"
+          monorepo-tags: true
+          prerelease: ${{ fromJson(steps.is-prerelease.outputs.result) }}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@changesets/cli": "^2.26.2",
     "@commitlint/cli": "^17.8.0",
     "@commitlint/config-conventional": "^17.8.0",
+    "@manypkg/get-packages": "^2.2.0",
     "@storybook/react": "^7.4.6",
     "@swc-node/jest": "^1.6.8",
     "@swc/core": "^1.3.96",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^17.8.0
         version: 17.8.0
+      '@manypkg/get-packages':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@storybook/react':
         specifier: ^7.4.6
         version: 7.4.6(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
@@ -4974,6 +4977,15 @@ packages:
       fs-extra: 8.1.0
     dev: true
 
+  /@manypkg/find-root@2.2.1:
+    resolution: {integrity: sha512-34NlypD5mmTY65cFAK7QPgY5Tzt0qXR4ZRXdg97xAlkiLuwXUPBEXy5Hsqzd+7S2acsLxUz6Cs50rlDZQr4xUA==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@manypkg/tools': 1.1.0
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+    dev: true
+
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
@@ -4982,6 +4994,24 @@ packages:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
+      read-yaml-file: 1.1.0
+    dev: true
+
+  /@manypkg/get-packages@2.2.0:
+    resolution: {integrity: sha512-B5p5BXMwhGZKi/syEEAP1eVg5DZ/9LP+MZr0HqfrHLgu9fq0w4ZwH8yVen4JmjrxI2dWS31dcoswYzuphLaRxg==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@manypkg/find-root': 2.2.1
+      '@manypkg/tools': 1.1.0
+    dev: true
+
+  /@manypkg/tools@1.1.0:
+    resolution: {integrity: sha512-SkAyKAByB9l93Slyg8AUHGuM2kjvWioUTCckT/03J09jYnfEzMO/wSXmEhnKGYs6qx9De8TH4yJCl0Y9lRgnyQ==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      jju: 1.4.0
       read-yaml-file: 1.1.0
     dev: true
 
@@ -18043,6 +18073,10 @@ packages:
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
+
+  /jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: true
 
   /joi@17.11.0:
     resolution: {integrity: sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==}

--- a/scripts/get-apps-changed.js
+++ b/scripts/get-apps-changed.js
@@ -1,0 +1,52 @@
+const path = require('path')
+const getPackagesSync = require('@manypkg/get-packages').getPackagesSync
+const execSync = require('node:child_process').execSync
+
+function getApplicationsChanged() {
+  const appsDir = path.resolve(process.cwd())
+  const packagesSync = getPackagesSync(appsDir)
+
+  function getApps() {
+    return packagesSync.packages.filter((package) => {
+      const isApp = /^apps\/*/gi.test(package.relativeDir)
+      const isHasNameAndVersion =
+        package.packageJson.name && package.packageJson.version
+      return isApp && isHasNameAndVersion
+    })
+  }
+
+  const appsPackages = getApps()
+  if (!appsPackages.length) {
+    console.info(
+      'Not found any application packages in the',
+      '\x1b[31m"/apps"\x1b[0m',
+      'folder !',
+    )
+    return null
+  }
+
+  const fromCommit = process.env.FROM_COMMIT || ''
+  const toCommit = process.env.TO_COMMIT || 'HEAD^'
+  const commandGetChanged = `npx -y turbo build --dry-run=json --filter={./apps/*}[${fromCommit}...${toCommit}]`
+  const output = execSync(commandGetChanged, {
+    encoding: 'utf-8',
+  })
+  const parsedOutput = JSON.parse(output)
+  const packages = parsedOutput.packages
+
+  if (!packages || !packages.length) {
+    return null
+  }
+
+  const applications = appsPackages.filter((p) => {
+    return packages.some((package) => p.packageJson.name === package)
+  })
+
+  if (!applications.length) {
+    return null
+  }
+
+  return applications.map((p) => p.relativeDir)
+}
+
+module.exports = getApplicationsChanged


### PR DESCRIPTION
**What does this PR do?**

- [x]  add releasing yml for applications

**Key Changes**

- Use Google Github Actions Release Please for Applications releasing phases
- https://github.com/googleapis/release-please

- Auto detect applications changed and run Matrix Strategy on github actions to bump the version

**Releasing Flow**

1. Merge commit to the `main` branch (or `staging` for prerelease)
2. The github actions will create a PR for updating `CHANGELOGS.md` and `package.json` version
![image](https://github.com/consolelabs/web-foundation/assets/71743905/9da74293-9d06-471f-929a-78f505388ccc)
3. Merge the PR changelogs will bump the package version and Create github Release
![image](https://github.com/consolelabs/web-foundation/assets/71743905/94e7f52f-f415-4a0e-a07e-bb6d1e1a76d4)

All flows will be handled on Github actions