### PR TITLE
refactor: replace alert with toast

### DIFF
--- a/apps/mochi-web/components/Pay/ShareButton.tsx
+++ b/apps/mochi-web/components/Pay/ShareButton.tsx
@@ -1,9 +1,12 @@
 import { useClipboard } from '@dwarvesf/react-hooks'
 import { Icon } from '@iconify/react'
+import { useToast } from '@mochi-ui/core'
 import { Button } from '~cpn/base/button'
 
 export default function ShareButton({ link }: { link: string }) {
   const { onCopy } = useClipboard(link)
+  const { toast } = useToast()
+
   return (
     <Button
       type="button"
@@ -16,7 +19,9 @@ export default function ShareButton({ link }: { link: string }) {
         } else {
           // Copy link if can't share
           onCopy()
-          alert('Link Copied')
+          toast({
+            description: 'Link Copied',
+          })
         }
       }}
     >

--- a/apps/mochi-web/components/app/DeleteAppModal.tsx
+++ b/apps/mochi-web/components/app/DeleteAppModal.tsx
@@ -12,6 +12,7 @@ import {
   TextFieldInput,
   TextFieldRoot,
   Typography,
+  useToast,
 } from '@mochi-ui/core'
 import { AlertCircleLine } from '@mochi-ui/icons'
 import { useEffect } from 'react'
@@ -65,6 +66,7 @@ export const DeleteAppModal = ({
     resolver: zodResolver(schema),
     mode: 'onChange',
   })
+  const { toast } = useToast()
   const { id, name } = app || {}
 
   useEffect(() => {
@@ -88,7 +90,10 @@ export const DeleteAppModal = ({
       })
       .catch((e) => {
         const err = JSON.parse(e.message)
-        alert(err.msg)
+        toast({
+          description: err.msg,
+          scheme: 'danger',
+        })
         onError?.()
       })
   }

--- a/apps/mochi-web/components/app/NewAppForm.tsx
+++ b/apps/mochi-web/components/app/NewAppForm.tsx
@@ -1,4 +1,4 @@
-import { Button, TextFieldInput, Typography } from '@mochi-ui/core'
+import { Button, TextFieldInput, Typography, useToast } from '@mochi-ui/core'
 import {
   DtoCreateApplicationRequest,
   ViewFullApplicationResponse,
@@ -36,6 +36,7 @@ export default function NewAppForm({ id, onClose, onSuccess, onError }: Props) {
     },
     resolver: zodResolver(schema),
   })
+  const { toast } = useToast()
 
   const onCreateApp = (data: DtoCreateApplicationRequest) => {
     if (!id) return
@@ -54,7 +55,10 @@ export default function NewAppForm({ id, onClose, onSuccess, onError }: Props) {
       })
       .catch((e) => {
         const err = JSON.parse(e.message)
-        alert(err.msg)
+        toast({
+          description: err.msg,
+          scheme: 'danger',
+        })
         onError?.()
       })
   }

--- a/apps/mochi-web/components/app/detail/AppDetailStatistics.tsx
+++ b/apps/mochi-web/components/app/detail/AppDetailStatistics.tsx
@@ -6,6 +6,7 @@ import {
   FormErrorMessage,
   FormLabel,
   IconButton,
+  useToast,
 } from '@mochi-ui/core'
 import {
   EditLine,
@@ -38,6 +39,7 @@ export const AppDetailStatistics = ({
   control,
   refresh,
 }: Props) => {
+  const { toast } = useToast()
   const { data: stats } = useFetchApplicationDetailStats(profileId, appId)
   const [editing, setEditing] = useState('')
   const inputFile = useRef<HTMLInputElement>(null)
@@ -48,7 +50,10 @@ export const AppDetailStatistics = ({
     const file = e.target.files?.[0]
     if (!file || !profileId || !appId) return
     if (file.size > 1024 * 1024 * 1) {
-      alert('File size must be less than 1MB')
+      toast({
+        description: 'File size must be less than 1MB',
+        scheme: 'danger',
+      })
       return
     }
     setUploading(true)
@@ -64,7 +69,10 @@ export const AppDetailStatistics = ({
       })
       .catch((e) => {
         const err = JSON.parse(e.message)
-        alert(err.msg)
+        toast({
+          description: err.msg,
+          scheme: 'danger',
+        })
       })
       .finally(() => {
         setUploading(false)

--- a/apps/mochi-web/pages/_app.tsx
+++ b/apps/mochi-web/pages/_app.tsx
@@ -9,7 +9,7 @@ import '~styles/nprogress.css'
 import { useRouter } from 'next/router'
 import Script from 'next/script'
 import { interFont } from '~utils/next-font'
-import { useLoginWidget } from '@mochi-ui/core'
+import { Toaster, useLoginWidget } from '@mochi-ui/core'
 import { LazyMotion, domAnimation } from 'framer-motion'
 import { useAuthStore } from '../store/auth'
 import { SidebarContextProvider } from '../context/app/sidebar'
@@ -21,7 +21,6 @@ const WalletProvider = dynamic(() =>
 const LoginWidgetProvider = dynamic(() =>
   import('@mochi-ui/core').then((m) => m.LoginWidgetProvider),
 )
-const Toaster = dynamic(() => import('sonner').then((m) => m.Toaster))
 
 const TopProgressBar = dynamic(() => import('~app/layout/nprogress'), {
   ssr: false,
@@ -77,13 +76,9 @@ function InnerApp({ Component, pageProps }: AppPropsWithLayout) {
 export default function App(props: AppPropsWithLayout) {
   return (
     <StrictMode>
-      <Toaster
-        position="top-right"
-        closeButton
-        toastOptions={{
-          className: 'w-full',
-        }}
-      />
+      <div className="fixed z-50 top-3 right-3">
+        <Toaster />
+      </div>
       <TopProgressBar />
       <Script async src="https://telegram.org/js/telegram-widget.js?22" />
       <WalletProvider>

--- a/apps/mochi-web/pages/applications/[id].tsx
+++ b/apps/mochi-web/pages/applications/[id].tsx
@@ -15,7 +15,7 @@ import {
 import { API, GET_PATHS } from '~constants/api'
 import { useForm } from 'react-hook-form'
 import { useEffect, useState } from 'react'
-import { Button } from '@mochi-ui/core'
+import { Button, useToast } from '@mochi-ui/core'
 import { AppDetailFormValues } from '~types/app'
 import { AppDetailPlatforms } from '~cpn/app/detail/AppDetailPlatforms'
 import { platforms } from '~constants/app'
@@ -83,6 +83,7 @@ const App: NextPageWithLayout = () => {
     push,
   } = useRouter()
   const appId = id as string
+  const { toast } = useToast()
   const { data: detail, mutate: refresh } = useFetchApplicationDetail(
     profileId,
     appId,
@@ -131,11 +132,17 @@ const App: NextPageWithLayout = () => {
     )
       .json(() => {
         refresh()
-        alert('Updated successfully')
+        toast({
+          description: 'Updated successfully',
+          scheme: 'success',
+        })
       })
       .catch((e) => {
         const err = JSON.parse(e.message)
-        alert(err.msg)
+        toast({
+          description: err.msg,
+          scheme: 'danger',
+        })
       })
   }
 
@@ -152,7 +159,10 @@ const App: NextPageWithLayout = () => {
       })
       .catch((e) => {
         const err = JSON.parse(e.message)
-        alert(err.msg)
+        toast({
+          description: err.msg,
+          scheme: 'danger',
+        })
       })
       .finally(() => {
         setIsResettingSecretKey(false)


### PR DESCRIPTION
**What does this PR do?**

- [ ] Use the new toast component to handle alert

**Related Ticket(s)**

- https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=4e282e12206a42ada9a835e06bfe74a0&pm=s

**Media (Loom or gif)**
![image](https://github.com/consolelabs/mochi-ui/assets/44285614/0ee429dd-f4d2-4333-9cbb-419b6e54cf00)
