### PR TITLE
feat: network and platform filters for explore transaction table

### DIFF
--- a/apps/mochi-web/components/MochiWidget/PlatformPicker/type.ts
+++ b/apps/mochi-web/components/MochiWidget/PlatformPicker/type.ts
@@ -1,10 +1,7 @@
-import { SVGProps } from 'react'
-
 // TODO: replace it with Mochi Types
 export type Platform = {
   id: string
-  name: PlatformType
-  icon: (props: SVGProps<SVGSVGElement>) => JSX.Element
+  platform: PlatformType
 }
 
 export type PlatformType =

--- a/apps/mochi-web/components/MochiWidget/PlatformPicker/type.ts
+++ b/apps/mochi-web/components/MochiWidget/PlatformPicker/type.ts
@@ -1,7 +1,10 @@
+import { SVGProps } from 'react'
+
 // TODO: replace it with Mochi Types
 export type Platform = {
   id: string
-  platform: PlatformType
+  name: PlatformType
+  icon: (props: SVGProps<SVGSVGElement>) => JSX.Element
 }
 
 export type PlatformType =

--- a/apps/mochi-web/components/TransactionTable/TransactionTable.tsx
+++ b/apps/mochi-web/components/TransactionTable/TransactionTable.tsx
@@ -193,8 +193,8 @@ export const TransactionTable = (props: TransactionTableProps) => {
               className={clsx(
                 'inline-flex',
                 tx.isSuccess
-                  ? 'bg-success-outline text-success-solid'
-                  : 'bg-danger-outline text-danger-solid',
+                  ? '!bg-success-outline !text-success-solid'
+                  : '!bg-danger-outline !text-danger-solid',
               )}
               appearance="white"
             >

--- a/apps/mochi-web/components/TransactionTable/utils.ts
+++ b/apps/mochi-web/components/TransactionTable/utils.ts
@@ -23,7 +23,10 @@ const actionString: Record<OffchainTx['action'], string> = {
 
 export async function transform(d: any): Promise<Tx> {
   let [from, to] = UI.render(Platform.Web, d.from_profile, d.other_profile)
-  let [fromAvatar, toAvatar] = [d.from_profile.avatar, d.other_profile.avatar]
+  let [fromAvatar, toAvatar] = [
+    d.from_profile?.avatar || '',
+    d.other_profile?.avatar || '',
+  ]
 
   const fromPlatform = d.source_platform
   let fromPlatformIcon

--- a/apps/mochi-web/components/TransactionTable/utils.ts
+++ b/apps/mochi-web/components/TransactionTable/utils.ts
@@ -1,5 +1,6 @@
 import { OffchainTx } from '@consolelabs/mochi-rest'
 import UI, { Platform, utils as mochiUtils } from '@consolelabs/mochi-formatter'
+import { truncate } from '@dwarvesf/react-utils'
 import { MonitorLine } from '@mochi-ui/icons'
 import { utils } from 'ethers'
 import { Tx } from '~cpn/TransactionTable'
@@ -132,6 +133,12 @@ export async function transform(d: any): Promise<Tx> {
 
   if (to?.platform === Platform.Mochi) {
     to.plain = '🍡 Mochi user'
+  }
+
+  if (to && d.action === 'withdraw') {
+    to.plain = truncate(d.other_profile_source, 8, true, '.')
+  } else if (from && d.action === 'deposit') {
+    from.plain = truncate(d.from_profile_source, 8, true, '.')
   }
 
   return {

--- a/apps/mochi-web/components/explore/index/components/ChainPicker.tsx
+++ b/apps/mochi-web/components/explore/index/components/ChainPicker.tsx
@@ -7,7 +7,6 @@ import {
 } from '@mochi-ui/core'
 import { LinkLine } from '@mochi-ui/icons'
 import { networkFilters } from '~constants/transactions'
-import { Chains } from '~cpn/MochiWidget/ChainPicker/data'
 
 export type ChainPickerProps = {
   value: string
@@ -17,12 +16,23 @@ export type ChainPickerProps = {
 export const ChainPicker = (props: ChainPickerProps) => {
   const { value, onChange } = props
 
-  const selectedChain = Chains.find((chain) => chain.id === Number(value))
+  const selectedNetwork = networkFilters.find(
+    (network) => network.value === value,
+  )
 
   return (
     <Select value={value} onChange={(v) => onChange(v === 'all' ? '' : v)}>
       <SelectTrigger
-        leftIcon={selectedChain ? <selectedChain.icon /> : <LinkLine />}
+        leftIcon={
+          // eslint-disable-next-line
+          selectedNetwork ? (
+            selectedNetwork.icon ? (
+              <selectedNetwork.icon />
+            ) : undefined
+          ) : (
+            <LinkLine />
+          )
+        }
         className="border border-divider !font-normal"
       >
         <SelectValue placeholder="All Networks" />

--- a/apps/mochi-web/components/explore/index/components/ChainPicker.tsx
+++ b/apps/mochi-web/components/explore/index/components/ChainPicker.tsx
@@ -1,0 +1,45 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@mochi-ui/core'
+import { LinkLine } from '@mochi-ui/icons'
+import { networkFilters } from '~constants/transactions'
+import { Chains } from '~cpn/MochiWidget/ChainPicker/data'
+
+export type ChainPickerProps = {
+  value: string
+  onChange: (value: string) => void
+}
+
+export const ChainPicker = (props: ChainPickerProps) => {
+  const { value, onChange } = props
+
+  const selectedChain = Chains.find((chain) => chain.id === Number(value))
+
+  return (
+    <Select value={value} onChange={(v) => onChange(v === 'all' ? '' : v)}>
+      <SelectTrigger
+        leftIcon={selectedChain ? <selectedChain.icon /> : <LinkLine />}
+        className="border border-divider !font-normal"
+      >
+        <SelectValue placeholder="All Networks" />
+      </SelectTrigger>
+      <SelectContent className="min-w-[250px]">
+        {networkFilters.map((network) => {
+          return (
+            <SelectItem
+              key={network.value}
+              value={network.value}
+              leftIcon={network.icon ? <network.icon /> : undefined}
+            >
+              {network.label}
+            </SelectItem>
+          )
+        })}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/apps/mochi-web/components/explore/index/components/PlatformPicker.tsx
+++ b/apps/mochi-web/components/explore/index/components/PlatformPicker.tsx
@@ -7,7 +7,6 @@ import {
 } from '@mochi-ui/core'
 import { WebSolid } from '@mochi-ui/icons'
 import { platformFilters } from '~constants/transactions'
-import { Platforms } from '~cpn/MochiWidget/PlatformPicker'
 
 export type PlatformPickerProps = {
   value: string
@@ -17,7 +16,9 @@ export type PlatformPickerProps = {
 export const PlatformPicker = (props: PlatformPickerProps) => {
   const { value, onChange } = props
 
-  const selectedPlatform = Platforms.find((platform) => platform.id === value)
+  const selectedPlatform = platformFilters.find(
+    (platform) => platform.value === value,
+  )
 
   return (
     <Select value={value} onChange={(v) => onChange(v === 'all' ? '' : v)}>

--- a/apps/mochi-web/components/explore/index/components/PlatformPicker.tsx
+++ b/apps/mochi-web/components/explore/index/components/PlatformPicker.tsx
@@ -1,0 +1,46 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@mochi-ui/core'
+import { WebSolid } from '@mochi-ui/icons'
+import { platformFilters } from '~constants/transactions'
+import { Platforms } from '~cpn/MochiWidget/PlatformPicker'
+
+export type PlatformPickerProps = {
+  value: string
+  onChange: (value: string) => void
+}
+
+export const PlatformPicker = (props: PlatformPickerProps) => {
+  const { value, onChange } = props
+
+  const selectedPlatform = Platforms.find((platform) => platform.id === value)
+
+  return (
+    <Select value={value} onChange={(v) => onChange(v === 'all' ? '' : v)}>
+      <SelectTrigger
+        leftIcon={selectedPlatform ? <selectedPlatform.icon /> : <WebSolid />}
+        className="border border-divider !font-normal capitalize"
+      >
+        <SelectValue placeholder="All Platforms" />
+      </SelectTrigger>
+      <SelectContent className="min-w-[250px]">
+        {platformFilters.map((platform) => {
+          return (
+            <SelectItem
+              key={platform.value}
+              value={platform.value}
+              leftIcon={<platform.icon />}
+              className="capitalize"
+            >
+              {platform.label}
+            </SelectItem>
+          )
+        })}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/apps/mochi-web/components/explore/index/components/index.ts
+++ b/apps/mochi-web/components/explore/index/components/index.ts
@@ -1,0 +1,2 @@
+export * from './ChainPicker'
+export * from './PlatformPicker'

--- a/apps/mochi-web/components/explore/index/sections/SummarySection.tsx
+++ b/apps/mochi-web/components/explore/index/sections/SummarySection.tsx
@@ -25,8 +25,11 @@ export const SummarySection = () => {
   const loading = isTransactionSummaryLoading || !transactionSummary
 
   return (
-    <div className="p-3 lg:py-14 bg-background-level2 lg:px-30">
-      <div className="grid gap-4 lg:grid-cols-12">
+    <div className="lg:py-14 bg-background-level2">
+      <div
+        className="grid gap-4 lg:grid-cols-12 p-6 mx-auto"
+        style={{ maxWidth: 1200 }}
+      >
         <div className="flex flex-wrap col-span-12 gap-4 justify-between items-center p-6 rounded-xl border bg-background-body border-divider">
           <div className="flex flex-col gap-4 w-full lg:w-auto">
             <div className="flex flex-col-4">
@@ -95,6 +98,7 @@ export const SummarySection = () => {
                       stroke="none"
                       startAngle={-270}
                       endAngle={90}
+                      innerRadius={36}
                     />
                   </PieChart>
                 </div>

--- a/apps/mochi-web/components/explore/index/sections/SummarySection.tsx
+++ b/apps/mochi-web/components/explore/index/sections/SummarySection.tsx
@@ -57,11 +57,11 @@ export const SummarySection = () => {
                 <>
                   <Typography level="h5" className="!text-primary-solid">
                     {formatNumber(
-                      transactionSummary.transactions_per_second || 0,
+                      Math.floor(transactionSummary.transactions_per_day) || 0,
                     )}
                   </Typography>
                   <Typography className="text-text-secondary">
-                    transactions per second
+                    transactions per day
                   </Typography>
                 </>
               )}

--- a/apps/mochi-web/components/explore/index/sections/TransactionSection.tsx
+++ b/apps/mochi-web/components/explore/index/sections/TransactionSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { ROUTES } from '~constants/routes'
 import { TransactionTable } from '~cpn/TransactionTable'
+import { ChainPicker, PlatformPicker } from '../components'
 import {
   DEFAULT_PAGE_SIZE,
   useTransactionStore,
@@ -15,6 +16,8 @@ export const TransactionSection = () => {
     total = 0,
     setPage,
     setSize,
+    filters,
+    setFilters,
     ws,
     initWs,
   } = useTransactionStore()
@@ -39,6 +42,16 @@ export const TransactionSection = () => {
 
   return (
     <div className="px-6" ref={containerRef}>
+      <div className="flex justify-end py-2 gap-4">
+        <ChainPicker
+          value={filters.chainId || ''}
+          onChange={(chainId) => setFilters({ chainId })}
+        />
+        <PlatformPicker
+          value={filters.platform || ''}
+          onChange={(platform) => setFilters({ platform })}
+        />
+      </div>
       <TransactionTable
         loadingRows={10}
         data={txnsCurrentPage}

--- a/apps/mochi-web/components/explore/index/sections/TransactionSection.tsx
+++ b/apps/mochi-web/components/explore/index/sections/TransactionSection.tsx
@@ -41,38 +41,40 @@ export const TransactionSection = () => {
   const isLoading = loading || !txnsCurrentPage
 
   return (
-    <div className="px-6" ref={containerRef}>
-      <div className="flex justify-end py-2 gap-4">
-        <ChainPicker
-          value={filters.chainId || ''}
-          onChange={(chainId) => setFilters({ chainId })}
-        />
-        <PlatformPicker
-          value={filters.platform || ''}
-          onChange={(platform) => setFilters({ platform })}
+    <div className="overflow-auto">
+      <div ref={containerRef} className="px-6 mx-auto" style={{ width: 1440 }}>
+        <div className="flex justify-end py-2 gap-4">
+          <ChainPicker
+            value={filters.chainId || ''}
+            onChange={(chainId) => setFilters({ chainId })}
+          />
+          <PlatformPicker
+            value={filters.platform || ''}
+            onChange={(platform) => setFilters({ platform })}
+          />
+        </div>
+        <TransactionTable
+          loadingRows={10}
+          data={txnsCurrentPage}
+          isLoading={isLoading}
+          onRow={(tx) => {
+            return {
+              onClick: () => {
+                window.open(ROUTES.TX_RECEIPTS(tx.code))
+              },
+            }
+          }}
+          componentsProps={{
+            pagination: {
+              initalPage: 1,
+              initItemsPerPage: DEFAULT_PAGE_SIZE,
+              totalItems: total,
+              onItemPerPageChange: setSize,
+              onPageChange: setPage,
+            },
+          }}
         />
       </div>
-      <TransactionTable
-        loadingRows={10}
-        data={txnsCurrentPage}
-        isLoading={isLoading}
-        onRow={(tx) => {
-          return {
-            onClick: () => {
-              window.open(ROUTES.TX_RECEIPTS(tx.code))
-            },
-          }
-        }}
-        componentsProps={{
-          pagination: {
-            initalPage: 1,
-            initItemsPerPage: DEFAULT_PAGE_SIZE,
-            totalItems: total,
-            onItemPerPageChange: setSize,
-            onPageChange: setPage,
-          },
-        }}
-      />
     </div>
   )
 }

--- a/apps/mochi-web/components/explore/index/stores/useTransactionSummaryStore.ts
+++ b/apps/mochi-web/components/explore/index/stores/useTransactionSummaryStore.ts
@@ -5,6 +5,7 @@ import { API } from '~constants/api'
 export type TransactionSummary = {
   current_transactions: number
   transactions_per_second: number
+  transactions_per_day: number
   success_transactions: number
   fail_transactions: number
   total_volume: number

--- a/apps/mochi-web/constants/transactions.ts
+++ b/apps/mochi-web/constants/transactions.ts
@@ -1,3 +1,19 @@
+import {
+  Arb,
+  Avalanche,
+  Base,
+  Bnb,
+  DiscordColored,
+  Eth,
+  Ftm,
+  LinkLine,
+  Matic,
+  Mnt,
+  WebSolid,
+} from '@mochi-ui/icons'
+import { SVGProps } from 'react'
+import Telegram from '~cpn/MochiWidget/PlatformPicker/icons/telegram-ic'
+
 export type TransactionActionType =
   | 'transfer'
   | 'vault_transfer'
@@ -47,21 +63,78 @@ export type TransactionPlatform = 'discord' | 'web' | 'telegram'
 export const platformFilters: {
   label: string
   value: TransactionPlatform | 'all'
+  icon: (props: SVGProps<SVGSVGElement>) => JSX.Element
 }[] = [
   {
     label: 'All Platforms',
     value: 'all',
+    icon: WebSolid,
   },
   {
     label: 'Web',
     value: 'web',
+    icon: WebSolid,
   },
   {
     label: 'Discord',
     value: 'discord',
+    icon: DiscordColored,
   },
   {
     label: 'Telegram',
     value: 'telegram',
+    icon: Telegram,
+  },
+]
+
+export const networkFilters: {
+  label: string
+  value: string
+  icon?: (props: SVGProps<SVGSVGElement>) => JSX.Element
+}[] = [
+  {
+    label: 'All Networks',
+    value: 'all',
+    icon: LinkLine,
+  },
+  {
+    label: 'Ethereum',
+    value: '1',
+    icon: Eth,
+  },
+  {
+    label: 'Binance',
+    value: '56',
+    icon: Bnb,
+  },
+  {
+    label: 'Base',
+    value: '8453',
+    icon: Base,
+  },
+  {
+    label: 'Fantom',
+    value: '250',
+    icon: Ftm,
+  },
+  {
+    label: 'Arbitrum',
+    value: '42161',
+    icon: Arb,
+  },
+  {
+    label: 'Avalanche',
+    value: '43114',
+    icon: Avalanche,
+  },
+  {
+    label: 'Mantle',
+    value: '5000',
+    icon: Mnt,
+  },
+  {
+    label: 'Polygon',
+    value: '137',
+    icon: Matic,
   },
 ]

--- a/apps/mochi-web/pages/explore.tsx
+++ b/apps/mochi-web/pages/explore.tsx
@@ -1,8 +1,14 @@
+import { useEffect } from 'react'
 import { Layout } from '~app/layout'
 import { SEO } from '~app/layout/seo'
 import { SummarySection, TransactionSection } from '~cpn/explore/index/sections'
 
 export default function ExplorePage() {
+  useEffect(() => {
+    // Scroll to top on mount
+    window.scrollTo(0, 0)
+  }, [])
+
   return (
     <Layout>
       <SEO title="Explore" />


### PR DESCRIPTION
**What does this PR do?**

- [x] Network and platform filters for Explore page > Transaction table

Please note that the API is incomplete. The params are there but will not be processed on the BE.

**Media**

<img width="446" alt="image" src="https://github.com/consolelabs/mochi-ui/assets/11691985/094a892b-cfef-46db-b13b-fc654dbf6270">
<img width="438" alt="image" src="https://github.com/consolelabs/mochi-ui/assets/11691985/d00e3589-0831-4ce1-b608-48f8b9137c22">

