### PR TITLE
fix: shrink scrollbar to table body only in tokenpicker

### DIFF
--- a/apps/mochi-web/components/TransactionTable/TransactionTable.tsx
+++ b/apps/mochi-web/components/TransactionTable/TransactionTable.tsx
@@ -219,7 +219,7 @@ export const TransactionTable = (props: TransactionTableProps) => {
 
   return (
     <>
-      <ScrollArea type="hover">
+      <ScrollArea>
         <ScrollAreaViewport>
           <div style={{ minWidth: 1400 }} className={className}>
             <Table {...rest} columns={columns} className="p-0" />

--- a/packages/components/scroll-area/src/scroll-area.tsx
+++ b/packages/components/scroll-area/src/scroll-area.tsx
@@ -22,9 +22,10 @@ const {
 } = scrollArea
 
 const ScrollArea = forwardRef<ElementRef<typeof Root>, ScrollAreaProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, type = 'scroll', ...props }, ref) => (
     <Root
       {...props}
+      type={type}
       ref={ref}
       className={scrollAreaRootClsx({
         className,


### PR DESCRIPTION
- show scrollbar on scroll only
