### PR TITLE
fix: shrink scrollbar in token picker to fit table body

### DIFF
--- a/apps/mochi-web/components/TokenTableList.tsx
+++ b/apps/mochi-web/components/TokenTableList.tsx
@@ -131,7 +131,7 @@ export const TokenTableList = ({
           ]}
         />
       </ScrollAreaViewport>
-      <ScrollAreaScrollbar orientation="vertical">
+      <ScrollAreaScrollbar orientation="vertical" className="mt-10">
         <ScrollAreaThumb />
       </ScrollAreaScrollbar>
       <ScrollAreaCorner className="bg-neutral-outline-hover" />


### PR DESCRIPTION
- shrink scrollbar to fit table body

<img width="321" alt="image" src="https://github.com/consolelabs/mochi-ui/assets/88917321/52cb9587-d236-4d22-b2aa-c3bb99045555">
