### PR TITLE
fix: require at lease one record for default message limit transaction

### DIFF
--- a/apps/mochi-web/components/settings/general/DefaultMessage.tsx
+++ b/apps/mochi-web/components/settings/general/DefaultMessage.tsx
@@ -4,10 +4,14 @@ import React from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { actionList } from '~constants/settings'
 import { ResponseGeneralSettingData } from '~types/mochi-schema'
+import { useDisclosure } from '@dwarvesf/react-hooks'
 import { MessageModal } from './MessageModal'
 
 export const DefaultMessage = () => {
-  const { control, watch } = useFormContext<ResponseGeneralSettingData>()
+  const { isOpen: isOpenMessageModal, onOpenChange: onOpenChangeMessageModal } =
+    useDisclosure()
+  const { control, watch, setValue } =
+    useFormContext<ResponseGeneralSettingData>()
   const { fields, append, remove, update } = useFieldArray({
     control,
     name: 'payment.default_message_settings',
@@ -25,7 +29,12 @@ export const DefaultMessage = () => {
             <Switch
               {...rest}
               checked={value}
-              onCheckedChange={(checked) => onChange(checked)}
+              onCheckedChange={(checked) => {
+                onChange(checked)
+                if (checked && !fields.length) {
+                  onOpenChangeMessageModal(true)
+                }
+              }}
             />
           )}
         />
@@ -57,12 +66,19 @@ export const DefaultMessage = () => {
                     <EditLine className="w-5 h-5" />
                   </IconButton>
                 }
+                open={isOpenMessageModal}
+                onOpenChange={onOpenChangeMessageModal}
               />
               <IconButton
                 label="Delete"
                 variant="ghost"
                 color="white"
-                onClick={() => remove(index)}
+                onClick={() => {
+                  remove(index)
+                  if (fields.length === 1) {
+                    setValue('payment.default_message_enable', false)
+                  }
+                }}
               >
                 <TrashBinLine className="w-5 h-5 text-danger-solid" />
               </IconButton>
@@ -72,12 +88,22 @@ export const DefaultMessage = () => {
       ))}
       {!!enableDefaultMessage && (
         <MessageModal
-          onConfirm={(data) => append(data)}
+          onConfirm={(data) => {
+            append(data)
+            onOpenChangeMessageModal(false)
+          }}
           trigger={
             <Button color="white" className="w-fit">
               Add a new default message
             </Button>
           }
+          open={isOpenMessageModal}
+          onOpenChange={(open) => {
+            onOpenChangeMessageModal(open)
+            if (!open && !fields.length) {
+              setValue('payment.default_message_enable', false)
+            }
+          }}
         />
       )}
     </div>

--- a/apps/mochi-web/components/settings/general/MessageModal.tsx
+++ b/apps/mochi-web/components/settings/general/MessageModal.tsx
@@ -17,7 +17,7 @@ import {
   TextFieldRoot,
   Typography,
 } from '@mochi-ui/core'
-import React, { useState } from 'react'
+import React from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -33,21 +33,23 @@ interface Props {
   defaultValues?: ModelDefaultMessageSetting
   onConfirm: (data: ModelDefaultMessageSetting) => void
   trigger: React.ReactNode
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
 
 export const MessageModal = ({
   defaultValues = { action: '', message: '' },
   onConfirm,
   trigger,
+  open,
+  onOpenChange,
 }: Props) => {
-  const [open, setOpen] = useState(false)
   const { control, handleSubmit, reset } = useForm<ModelDefaultMessageSetting>({
     defaultValues,
     resolver: zodResolver(schema),
   })
 
   const onSubmit = (data: ModelDefaultMessageSetting) => {
-    setOpen(false)
     onConfirm(data)
   }
 
@@ -55,7 +57,7 @@ export const MessageModal = ({
     <Modal
       open={open}
       onOpenChange={(open) => {
-        setOpen(open)
+        onOpenChange(open)
         reset(defaultValues)
       }}
     >

--- a/apps/mochi-web/components/settings/general/TokenPriority.tsx
+++ b/apps/mochi-web/components/settings/general/TokenPriority.tsx
@@ -54,7 +54,12 @@ export const TokenPriority = () => {
         }}
       >
         {fields.map((each, index) => (
-          <DndItem key={each.id} draggableId={each.id} index={index}>
+          <DndItem
+            key={each.id}
+            draggableId={each.id}
+            index={index}
+            className="py-2"
+          >
             <Controller
               key={each.id}
               name={`payment.prioritized_token.${index}`}

--- a/apps/mochi-web/components/settings/general/TransactionLimit.tsx
+++ b/apps/mochi-web/components/settings/general/TransactionLimit.tsx
@@ -5,10 +5,16 @@ import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { actionList } from '~constants/settings'
 import { utils as mochiUtils } from '@consolelabs/mochi-formatter'
 import { ResponseGeneralSettingData } from '~types/mochi-schema'
+import { useDisclosure } from '@dwarvesf/react-hooks'
 import { TransactionLimitModal } from './TransactionLimitModal'
 
 export const TransactionLimit = () => {
-  const { control, watch } = useFormContext<ResponseGeneralSettingData>()
+  const {
+    isOpen: isOpenTransactionLimit,
+    onOpenChange: onOpenChangeTransactionLimit,
+  } = useDisclosure()
+  const { control, watch, setValue } =
+    useFormContext<ResponseGeneralSettingData>()
   const { fields, append, remove, update } = useFieldArray({
     control,
     name: 'payment.tx_limit_settings',
@@ -26,7 +32,12 @@ export const TransactionLimit = () => {
             <Switch
               {...rest}
               checked={value}
-              onCheckedChange={(checked) => onChange(checked)}
+              onCheckedChange={(checked) => {
+                onChange(checked)
+                if (checked && !fields.length) {
+                  onOpenChangeTransactionLimit(true)
+                }
+              }}
             />
           )}
         />
@@ -65,12 +76,19 @@ export const TransactionLimit = () => {
                     <EditLine className="w-5 h-5" />
                   </IconButton>
                 }
+                open={isOpenTransactionLimit}
+                onOpenChange={onOpenChangeTransactionLimit}
               />
               <IconButton
                 label="Delete"
                 variant="ghost"
                 color="white"
-                onClick={() => remove(index)}
+                onClick={() => {
+                  remove(index)
+                  if (fields.length === 1) {
+                    setValue('payment.tx_limit_enable', false)
+                  }
+                }}
               >
                 <TrashBinLine className="w-5 h-5 text-danger-solid" />
               </IconButton>
@@ -80,12 +98,22 @@ export const TransactionLimit = () => {
       ))}
       {!!enableTransactionLimit && (
         <TransactionLimitModal
-          onConfirm={(data) => append(data)}
+          onConfirm={(data) => {
+            append(data)
+            onOpenChangeTransactionLimit(false)
+          }}
           trigger={
             <Button color="white" className="w-fit">
               Add a new limit
             </Button>
           }
+          open={isOpenTransactionLimit}
+          onOpenChange={(open) => {
+            onOpenChangeTransactionLimit(open)
+            if (!open && !fields.length) {
+              setValue('payment.tx_limit_enable', false)
+            }
+          }}
         />
       )}
     </div>

--- a/apps/mochi-web/components/settings/general/TransactionLimitModal.tsx
+++ b/apps/mochi-web/components/settings/general/TransactionLimitModal.tsx
@@ -18,7 +18,7 @@ import {
   TextFieldRoot,
   Typography,
 } from '@mochi-ui/core'
-import React, { useState } from 'react'
+import React from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -52,21 +52,23 @@ interface Props {
   defaultValues?: ModelTxLimitSetting
   onConfirm: (data: ModelTxLimitSetting) => void
   trigger: React.ReactNode
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
 
 export const TransactionLimitModal = ({
   defaultValues = {},
   onConfirm,
   trigger,
+  open,
+  onOpenChange,
 }: Props) => {
-  const [open, setOpen] = useState(false)
   const { control, handleSubmit, reset } = useForm<ModelTxLimitSetting>({
     defaultValues,
     resolver: zodResolver(schema),
   })
 
   const onSubmit = (data: ModelTxLimitSetting) => {
-    setOpen(false)
     onConfirm(data)
   }
 
@@ -74,7 +76,7 @@ export const TransactionLimitModal = ({
     <Modal
       open={open}
       onOpenChange={(open) => {
-        setOpen(open)
+        onOpenChange(open)
         reset(defaultValues)
       }}
     >


### PR DESCRIPTION
**What does this PR do?**

- [ ] Require at lease one record for Default message + Limit transaction

**Related Ticket(s)**

- https://www.notion.so/console-labs/e8a2f8df770942af8bc5df33760960c8?v=422febebdba24e178a8f593e333b1893&p=71c963c16e6543d698c220a9b1b3a08d&pm=s

**Media (Loom or gif)**

https://github.com/consolelabs/mochi-ui/assets/44285614/8b0fb214-873a-48d2-8b1f-bbfe412237c7


