### PR TITLE
feat: migrating alert component

### DIFF
--- a/.changeset/silly-grapes-live.md
+++ b/.changeset/silly-grapes-live.md
@@ -1,0 +1,8 @@
+---
+'@mochi-ui/action-bar': patch
+'@mochi-ui/alert': patch
+'@mochi-ui/toast': patch
+'@mochi-ui/core': patch
+---
+
+Remove `as` prop, support asChild for polymorphic

--- a/packages/components/action-bar/src/action-bar-action-group.tsx
+++ b/packages/components/action-bar/src/action-bar-action-group.tsx
@@ -1,19 +1,14 @@
-import {
-  AlertActionGroup,
-  AlertActionGroupProps,
-  PolymorphicAlertActionGroup,
-} from '@mochi-ui/alert'
-import { forwardRef } from 'react'
+import { AlertActionGroup, AlertActionGroupProps } from '@mochi-ui/alert'
+import { ElementRef, forwardRef } from 'react'
 
 type ActionBarActionGroupProps = AlertActionGroupProps
 
-type PolymorphicActionBarActionGroup = PolymorphicAlertActionGroup
-
-const ActionBarActionGroup = forwardRef((props, ref) => (
-  <AlertActionGroup ref={ref} {...props} />
-)) as PolymorphicActionBarActionGroup
+const ActionBarActionGroup = forwardRef<
+  ElementRef<typeof AlertActionGroup>,
+  ActionBarActionGroupProps
+>((props, ref) => <AlertActionGroup ref={ref} {...props} />)
 
 ActionBarActionGroup.displayName = 'ActionBarActionGroup'
 
 export { ActionBarActionGroup }
-export type { ActionBarActionGroupProps, PolymorphicActionBarActionGroup }
+export type { ActionBarActionGroupProps }

--- a/packages/components/action-bar/src/action-bar-action-group.tsx
+++ b/packages/components/action-bar/src/action-bar-action-group.tsx
@@ -1,7 +1,9 @@
-import { AlertActionGroup, AlertActionGroupProps } from '@mochi-ui/alert'
 import { ElementRef, forwardRef } from 'react'
+import { AlertActionGroup, AlertActionGroupProps } from '@mochi-ui/alert'
 
-type ActionBarActionGroupProps = AlertActionGroupProps
+// NOTE: this fix build err
+// The inferred type of 'ActionBarActionGroup' cannot be named without a reference to '../../alert/node_modules/@mochi-ui/theme/src'.
+interface ActionBarActionGroupProps extends AlertActionGroupProps {}
 
 const ActionBarActionGroup = forwardRef<
   ElementRef<typeof AlertActionGroup>,

--- a/packages/components/action-bar/src/action-bar-body.tsx
+++ b/packages/components/action-bar/src/action-bar-body.tsx
@@ -1,18 +1,16 @@
-import {
-  AlertBody,
-  AlertBodyProps,
-  PolymorphicAlertBody,
-} from '@mochi-ui/alert'
-import { forwardRef } from 'react'
+import { AlertBody, AlertBodyProps } from '@mochi-ui/alert'
+import { ElementRef, forwardRef } from 'react'
 
 type ActionBarBodyProps = AlertBodyProps
-type PolymorphicActionBarBody = PolymorphicAlertBody
 
-const ActionBarBody = forwardRef((props, ref) => {
+const ActionBarBody = forwardRef<
+  ElementRef<typeof AlertBody>,
+  ActionBarBodyProps
+>((props, ref) => {
   return <AlertBody {...props} ref={ref} />
-}) as PolymorphicActionBarBody
+})
 
 ActionBarBody.displayName = 'ActionBarBody'
 
 export { ActionBarBody }
-export type { ActionBarBodyProps, PolymorphicActionBarBody }
+export type { ActionBarBodyProps }

--- a/packages/components/action-bar/src/action-bar-cancel.tsx
+++ b/packages/components/action-bar/src/action-bar-cancel.tsx
@@ -1,21 +1,19 @@
-import {
-  AlertCancelButton,
-  AlertCancelProps,
-  PolymorphicAlertCancelButton,
-} from '@mochi-ui/alert'
+import { AlertCancelButton, AlertCancelProps } from '@mochi-ui/alert'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
-import { forwardRef } from 'react'
+import { ElementRef, forwardRef } from 'react'
 
 type ActionBarCancelButtonProps = AlertCancelProps
-type PolymorphicActionBarCancelButton = PolymorphicAlertCancelButton
 
-const ActionBarCancelButton = forwardRef((props, ref) => (
+const ActionBarCancelButton = forwardRef<
+  ElementRef<typeof AlertCancelButton>,
+  ActionBarCancelButtonProps
+>((props, ref) => (
   <PopoverPrimitive.Close asChild>
     <AlertCancelButton {...props} ref={ref} />
   </PopoverPrimitive.Close>
-)) as PolymorphicActionBarCancelButton
+))
 
 ActionBarCancelButton.displayName = 'ActionBarCancelButton'
 
 export { ActionBarCancelButton }
-export type { ActionBarCancelButtonProps, PolymorphicActionBarCancelButton }
+export type { ActionBarCancelButtonProps }

--- a/packages/components/action-bar/src/action-bar-confirm.tsx
+++ b/packages/components/action-bar/src/action-bar-confirm.tsx
@@ -1,18 +1,14 @@
-import {
-  AlertConfirmButton,
-  AlertConfirmProps,
-  PolymorphicAlertConfirmButton,
-} from '@mochi-ui/alert'
-import { forwardRef } from 'react'
+import { AlertConfirmButton, AlertConfirmProps } from '@mochi-ui/alert'
+import { ElementRef, forwardRef } from 'react'
 
 type ActionBarConfirmButtonProps = AlertConfirmProps
-type PolymorphicActionBarConfirmButton = PolymorphicAlertConfirmButton
 
-const ActionBarConfirmButton = forwardRef((props, ref) => (
-  <AlertConfirmButton {...props} ref={ref} />
-)) as PolymorphicActionBarConfirmButton
+const ActionBarConfirmButton = forwardRef<
+  ElementRef<typeof AlertConfirmButton>,
+  ActionBarConfirmButtonProps
+>((props, ref) => <AlertConfirmButton {...props} ref={ref} />)
 
 ActionBarConfirmButton.displayName = 'ActionBarConfirmButton'
 
 export { ActionBarConfirmButton }
-export type { ActionBarConfirmButtonProps, PolymorphicActionBarConfirmButton }
+export type { ActionBarConfirmButtonProps }

--- a/packages/components/action-bar/src/action-bar-content.tsx
+++ b/packages/components/action-bar/src/action-bar-content.tsx
@@ -34,6 +34,7 @@ const ActionBarContent = forwardRef<
     sideOffset,
     scheme,
     anchorClassName,
+    asChild,
     ...passProps
   } = props
 
@@ -46,6 +47,7 @@ const ActionBarContent = forwardRef<
     layout,
     size,
     scheme,
+    asChild,
   }
 
   return (

--- a/packages/components/action-bar/src/action-bar-description.tsx
+++ b/packages/components/action-bar/src/action-bar-description.tsx
@@ -1,18 +1,14 @@
-import {
-  AlertDescription,
-  AlertDescriptionProps,
-  PolymorphicAlertDescription,
-} from '@mochi-ui/alert'
-import { forwardRef } from 'react'
+import { AlertDescription, AlertDescriptionProps } from '@mochi-ui/alert'
+import { ElementRef, forwardRef } from 'react'
 
 type ActionBarDescriptionProps = AlertDescriptionProps
-type PolymorphicActionBarDescription = PolymorphicAlertDescription
 
-const ActionBarDescription = forwardRef((props, ref) => (
-  <AlertDescription {...props} ref={ref} />
-)) as PolymorphicActionBarDescription
+const ActionBarDescription = forwardRef<
+  ElementRef<typeof AlertDescription>,
+  ActionBarDescriptionProps
+>((props, ref) => <AlertDescription {...props} ref={ref} />)
 
 ActionBarDescription.displayName = 'ActionBarDescription'
 
-export type { ActionBarDescriptionProps, PolymorphicActionBarDescription }
+export type { ActionBarDescriptionProps }
 export { ActionBarDescription }

--- a/packages/components/action-bar/src/action-bar-title.tsx
+++ b/packages/components/action-bar/src/action-bar-title.tsx
@@ -1,18 +1,14 @@
-import {
-  AlertTitle,
-  AlertTitleProps,
-  PolymorphicAlertTitle,
-} from '@mochi-ui/alert'
-import { forwardRef } from 'react'
+import { AlertTitle, AlertTitleProps } from '@mochi-ui/alert'
+import { ElementRef, forwardRef } from 'react'
 
 type ActionBarTitleProps = AlertTitleProps
-type PolymorphicActionbarTitle = PolymorphicAlertTitle
 
-const ActionBarTitle = forwardRef((props, ref) => (
-  <AlertTitle {...props} ref={ref} />
-)) as PolymorphicActionbarTitle
+const ActionBarTitle = forwardRef<
+  ElementRef<typeof AlertTitle>,
+  ActionBarTitleProps
+>((props, ref) => <AlertTitle {...props} ref={ref} />)
 
 ActionBarTitle.displayName = 'ActionBarTitle'
 
 export { ActionBarTitle }
-export type { PolymorphicActionbarTitle, ActionBarTitleProps }
+export type { ActionBarTitleProps }

--- a/packages/components/action-bar/src/action-bar-trigger.tsx
+++ b/packages/components/action-bar/src/action-bar-trigger.tsx
@@ -1,11 +1,15 @@
-import { forwardRef } from 'react'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
 
+type ActionBarTriggerProps = ComponentPropsWithoutRef<
+  typeof PopoverPrimitive.Trigger
+>
 const ActionBarTrigger = forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>
+  ElementRef<typeof PopoverPrimitive.Trigger>,
+  ActionBarTriggerProps
 >((props, ref) => <PopoverPrimitive.Trigger ref={ref} {...props} />)
 
 ActionBarTrigger.displayName = 'ActionBarTrigger'
 
 export { ActionBarTrigger }
+export type { ActionBarTriggerProps }

--- a/packages/components/alert/package.json
+++ b/packages/components/alert/package.json
@@ -36,7 +36,6 @@
     "@mochi-ui/button": "workspace:*",
     "@mochi-ui/icon-button": "workspace:*",
     "@mochi-ui/icons": "workspace:*",
-    "@mochi-ui/polymorphic": "workspace:*",
     "@mochi-ui/theme": "workspace:*",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",

--- a/packages/components/alert/src/alert-action-group.tsx
+++ b/packages/components/alert/src/alert-action-group.tsx
@@ -1,43 +1,33 @@
 import { alert, alertActionGroupStyleProps } from '@mochi-ui/theme'
-import { ComponentPropsWithRef, forwardRef } from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertActionGroup = Polymorphic.ForwardRefComponent<
-  'div',
-  {
-    asChild?: boolean
-  } & alertActionGroupStyleProps
->
+type AlertActionGroupProps = ComponentPropsWithoutRef<'div'> & {
+  asChild?: boolean
+} & alertActionGroupStyleProps
 
-type AlertActionGroupProps = ComponentPropsWithRef<PolymorphicAlertActionGroup>
+const AlertActionGroup = forwardRef<ElementRef<'div'>, AlertActionGroupProps>(
+  (props, ref) => {
+    const { className, asChild, layout: layoutProp, ...restProps } = props
+    const { layout: layoutContext, size, scheme } = useAlertContext()
 
-const AlertActionGroup = forwardRef((props, ref) => {
-  const {
-    className,
-    as = 'div',
-    layout: layoutProp,
-    asChild,
-    ...restProps
-  } = props
-  const { layout: layoutContext, size, scheme } = useAlertContext()
+    const Component = asChild ? Slot : 'div'
+    const layout = layoutProp ?? layoutContext
 
-  const Component = asChild ? Slot : as
-  const layout = layoutProp ?? layoutContext
-
-  return (
-    <Component
-      data-layout={layout}
-      data-scheme={scheme}
-      data-size={size}
-      className={alert.alertActionGroupCva({ layout, className })}
-      ref={ref}
-      {...restProps}
-    />
-  )
-}) as PolymorphicAlertActionGroup
+    return (
+      <Component
+        data-layout={layout}
+        data-scheme={scheme}
+        data-size={size}
+        className={alert.alertActionGroupCva({ layout, className })}
+        ref={ref}
+        {...restProps}
+      />
+    )
+  },
+)
 AlertActionGroup.displayName = 'AlertActionGroup'
 
 export { AlertActionGroup }
-export type { PolymorphicAlertActionGroup, AlertActionGroupProps }
+export type { AlertActionGroupProps }

--- a/packages/components/alert/src/alert-body.tsx
+++ b/packages/components/alert/src/alert-body.tsx
@@ -1,47 +1,42 @@
-import { ComponentPropsWithRef, forwardRef } from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { AlertBodyStyleProps, alert } from '@mochi-ui/theme'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertBody = Polymorphic.ForwardRefComponent<
-  'div',
-  {
-    asChild?: boolean
-  } & AlertBodyStyleProps
->
+type AlertBodyProps = ComponentPropsWithoutRef<'div'> & {
+  asChild?: boolean
+} & AlertBodyStyleProps
 
-type AlertBodyProps = ComponentPropsWithRef<PolymorphicAlertBody>
+const AlertBody = forwardRef<ElementRef<'div'>, AlertBodyProps>(
+  (props, ref) => {
+    const {
+      asChild,
+      className,
+      layout: layoutProp,
+      children,
+      ...restProps
+    } = props
+    const { layout: layoutContext, scheme, size } = useAlertContext()
 
-const AlertBody = forwardRef((props, ref) => {
-  const {
-    asChild,
-    as = 'div',
-    className,
-    layout: layoutProp,
-    children,
-    ...restProps
-  } = props
-  const { layout: layoutContext, scheme, size } = useAlertContext()
+    const layout = layoutProp ?? layoutContext
+    const Component = asChild ? Slot : 'div'
+    const passProps = asChild ? {} : { ref, ...restProps }
 
-  const layout = layoutProp ?? layoutContext
-  const Component = asChild ? Slot : as
-  const passProps = asChild ? {} : { ref, ...restProps }
-
-  return (
-    <Component
-      ref={ref}
-      data-layout={layout}
-      data-scheme={scheme}
-      data-size={size}
-      className={alert.alertBodyCva({ layout, className })}
-      {...passProps}
-    >
-      {children}
-    </Component>
-  )
-}) as PolymorphicAlertBody
+    return (
+      <Component
+        ref={ref}
+        data-layout={layout}
+        data-scheme={scheme}
+        data-size={size}
+        className={alert.alertBodyCva({ layout, className })}
+        {...passProps}
+      >
+        {children}
+      </Component>
+    )
+  },
+)
 AlertBody.displayName = 'AlertBody'
 
 export { AlertBody }
-export type { AlertBodyProps, PolymorphicAlertBody }
+export type { AlertBodyProps }

--- a/packages/components/alert/src/alert-cancel.tsx
+++ b/packages/components/alert/src/alert-cancel.tsx
@@ -1,22 +1,18 @@
 import { Button, ButtonProps } from '@mochi-ui/button'
-import { ComponentPropsWithRef, forwardRef } from 'react'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
-import { Slot } from '@radix-ui/react-slot'
-import * as Polymorphic from '@mochi-ui/polymorphic'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertCancelButton = Polymorphic.ForwardRefComponent<
-  'button',
+type AlertCancelProps = ComponentPropsWithoutRef<typeof Button> &
   ButtonProps & {
     asChild?: boolean
   }
->
 
-type AlertCancelProps = ComponentPropsWithRef<PolymorphicAlertCancelButton>
-
-const AlertCancelButton = forwardRef((props, ref) => {
+const AlertCancelButton = forwardRef<
+  ElementRef<typeof Button>,
+  AlertCancelProps
+>((props, ref) => {
   const {
-    asChild,
     className,
     variant: variantProp,
     color: colorProp,
@@ -24,16 +20,16 @@ const AlertCancelButton = forwardRef((props, ref) => {
     ...restProps
   } = props
   const { scheme, layout, size } = useAlertContext()
-  const Component = asChild ? Slot : Button
-  const passProps = asChild
-    ? {}
-    : {
-        variant: variantProp ?? layout === 'inline' ? 'link' : 'solid',
-        color: colorProp ?? 'white',
-        ...restProps,
-      }
+  const passProps = {
+    variant:
+      variantProp ?? layout === 'inline'
+        ? ('link' as const) // Ensure type compatible, otherwise will be indicated as type string
+        : ('solid' as const),
+    color: colorProp ?? 'white',
+    ...restProps,
+  }
   return (
-    <Component
+    <Button
       data-scheme={scheme}
       data-layout={layout}
       data-size={size}
@@ -42,10 +38,10 @@ const AlertCancelButton = forwardRef((props, ref) => {
       {...passProps}
     >
       {children}
-    </Component>
+    </Button>
   )
-}) as PolymorphicAlertCancelButton
+})
 AlertCancelButton.displayName = 'AlertCancelButton'
 
 export { AlertCancelButton }
-export type { AlertCancelProps, PolymorphicAlertCancelButton }
+export type { AlertCancelProps }

--- a/packages/components/alert/src/alert-cancel.tsx
+++ b/packages/components/alert/src/alert-cancel.tsx
@@ -1,12 +1,11 @@
-import { Button, ButtonProps } from '@mochi-ui/button'
+import { Button } from '@mochi-ui/button'
 import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { useAlertContext } from './context'
 
-type AlertCancelProps = ComponentPropsWithoutRef<typeof Button> &
-  ButtonProps & {
-    asChild?: boolean
-  }
+type AlertCancelProps = ComponentPropsWithoutRef<typeof Button> & {
+  asChild?: boolean
+}
 
 const AlertCancelButton = forwardRef<
   ElementRef<typeof Button>,

--- a/packages/components/alert/src/alert-close.tsx
+++ b/packages/components/alert/src/alert-close.tsx
@@ -1,21 +1,21 @@
-import { ComponentPropsWithRef, forwardRef } from 'react'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { CloseLgLine } from '@mochi-ui/icons'
 import { Slot } from '@radix-ui/react-slot'
-import { IconButton, IconButtonProps } from '@mochi-ui/icon-button'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { IconButton } from '@mochi-ui/icon-button'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertCloseButton = Polymorphic.ForwardRefComponent<
-  'button',
-  Omit<IconButtonProps, 'label'> & {
-    asChild?: boolean
-  }
->
+type AlertCloseButtonProps = Omit<
+  ComponentPropsWithoutRef<typeof IconButton>,
+  'label'
+> & {
+  asChild?: boolean
+}
 
-type AlertCloseButtonProps = ComponentPropsWithRef<PolymorphicAlertCloseButton>
-
-const AlertCloseButton = forwardRef((props, ref) => {
+const AlertCloseButton = forwardRef<
+  ElementRef<typeof IconButton>,
+  AlertCloseButtonProps
+>((props, ref) => {
   const { scheme, layout, size } = useAlertContext()
   const { className, asChild, ...restProps } = props
 
@@ -55,11 +55,7 @@ const AlertCloseButton = forwardRef((props, ref) => {
       <CloseLgLine />
     </IconButton>
   )
-}) as PolymorphicAlertCloseButton
+})
 AlertCloseButton.displayName = 'AlertCloseButton'
 
-export {
-  type PolymorphicAlertCloseButton,
-  type AlertCloseButtonProps,
-  AlertCloseButton,
-}
+export { type AlertCloseButtonProps, AlertCloseButton }

--- a/packages/components/alert/src/alert-confirm.tsx
+++ b/packages/components/alert/src/alert-confirm.tsx
@@ -1,20 +1,17 @@
-import { Button, ButtonProps } from '@mochi-ui/button'
-import { ComponentPropsWithRef, forwardRef } from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { Button } from '@mochi-ui/button'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { Slot } from '@radix-ui/react-slot'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertConfirmButton = Polymorphic.ForwardRefComponent<
-  'button',
-  ButtonProps & {
-    asChild?: boolean
-  }
->
+type AlertConfirmProps = ComponentPropsWithoutRef<typeof Button> & {
+  asChild?: boolean
+}
 
-type AlertConfirmProps = ComponentPropsWithRef<PolymorphicAlertConfirmButton>
-
-const AlertConfirmButton = forwardRef((props, ref) => {
+const AlertConfirmButton = forwardRef<
+  ElementRef<typeof Button>,
+  AlertConfirmProps
+>((props, ref) => {
   const {
     asChild,
     className,
@@ -45,11 +42,7 @@ const AlertConfirmButton = forwardRef((props, ref) => {
       {children}
     </Component>
   )
-}) as PolymorphicAlertConfirmButton
+})
 AlertConfirmButton.displayName = 'AlertConfirmButton'
 
-export {
-  type PolymorphicAlertConfirmButton,
-  type AlertConfirmProps,
-  AlertConfirmButton,
-}
+export { type AlertConfirmProps, AlertConfirmButton }

--- a/packages/components/alert/src/alert-description.tsx
+++ b/packages/components/alert/src/alert-description.tsx
@@ -1,44 +1,36 @@
-import { HTMLAttributes, forwardRef } from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { Slot } from '@radix-ui/react-slot'
 import { useAlertContext } from './context'
 
-type AlertDescriptionProps = HTMLAttributes<HTMLParagraphElement> & {
+type AlertDescriptionProps = ComponentPropsWithoutRef<'p'> & {
   asChild?: boolean
 }
 
-type PolymorphicAlertDescription = Polymorphic.ForwardRefComponent<
-  'p',
-  AlertDescriptionProps
->
+const AlertDescription = forwardRef<ElementRef<'p'>, AlertDescriptionProps>(
+  (props, ref) => {
+    const { asChild, className, ...restProps } = props
+    const { layout, scheme, size } = useAlertContext()
 
-const AlertDescription = forwardRef((props, ref) => {
-  const { as = 'p', asChild, className, ...restProps } = props
-  const { layout, scheme, size } = useAlertContext()
+    const Component = asChild ? Slot : 'p'
 
-  const Component = asChild ? Slot : as
-
-  return (
-    <Component
-      ref={ref}
-      className={alert.alertDescriptionCva({
-        scheme,
-        size,
-        layout,
-        className,
-      })}
-      data-size={size}
-      data-scheme={scheme}
-      data-layout={layout}
-      {...restProps}
-    />
-  )
-}) as PolymorphicAlertDescription
+    return (
+      <Component
+        ref={ref}
+        className={alert.alertDescriptionCva({
+          scheme,
+          size,
+          layout,
+          className,
+        })}
+        data-size={size}
+        data-scheme={scheme}
+        data-layout={layout}
+        {...restProps}
+      />
+    )
+  },
+)
 AlertDescription.displayName = 'AlertDescription'
 
-export {
-  AlertDescription,
-  type PolymorphicAlertDescription,
-  type AlertDescriptionProps,
-}
+export { AlertDescription, type AlertDescriptionProps }

--- a/packages/components/alert/src/alert-icon.tsx
+++ b/packages/components/alert/src/alert-icon.tsx
@@ -1,5 +1,5 @@
 import { InfoCircleOutlined, CheckCircleOutlined } from '@mochi-ui/icons'
-import { SVGProps, forwardRef } from 'react'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { Slot } from '@radix-ui/react-slot'
 import { useAlertContext } from './context'
@@ -10,32 +10,34 @@ const getIcons = (scheme: NonNullable<AlertProps['scheme']>) => {
   return InfoCircleOutlined
 }
 
-type AlertIconProps = SVGProps<SVGSVGElement> & { asChild?: boolean }
+type AlertIconProps = ComponentPropsWithoutRef<'svg'> & { asChild?: boolean }
 
-const AlertIcon = forwardRef<SVGSVGElement, AlertIconProps>((props, ref) => {
-  const { scheme, layout, size } = useAlertContext()
-  const { className, asChild, children, ...restProps } = props
+const AlertIcon = forwardRef<ElementRef<'svg'>, AlertIconProps>(
+  (props, ref) => {
+    const { scheme, layout, size } = useAlertContext()
+    const { className, asChild, children, ...restProps } = props
 
-  const Icon = getIcons(scheme)
-  const Component = asChild ? Slot : Icon
-  const passProps = asChild ? {} : { ref, ...restProps }
-  return (
-    <Component
-      data-size={size}
-      data-scheme={scheme}
-      data-layout={layout}
-      className={alert.alertIconCva({
-        scheme,
-        layout,
-        size,
-        className,
-      })}
-      {...passProps}
-    >
-      {children}
-    </Component>
-  )
-})
+    const Icon = getIcons(scheme)
+    const Component = asChild ? Slot : Icon
+    const passProps = asChild ? {} : { ref, ...restProps }
+    return (
+      <Component
+        data-size={size}
+        data-scheme={scheme}
+        data-layout={layout}
+        className={alert.alertIconCva({
+          scheme,
+          layout,
+          size,
+          className,
+        })}
+        {...passProps}
+      >
+        {children}
+      </Component>
+    )
+  },
+)
 
 AlertIcon.displayName = 'AlertIcon'
 

--- a/packages/components/alert/src/alert-link.tsx
+++ b/packages/components/alert/src/alert-link.tsx
@@ -1,22 +1,16 @@
-import { ComponentPropsWithRef, forwardRef } from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { Slot } from '@radix-ui/react-slot'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertLink = Polymorphic.ForwardRefComponent<
-  'a',
-  {
-    asChild?: boolean
-  }
->
+type AlertLinkProps = ComponentPropsWithoutRef<'a'> & {
+  asChild?: boolean
+}
 
-type AlertLinkProps = ComponentPropsWithRef<PolymorphicAlertLink>
-
-const AlertLink = forwardRef((props, ref) => {
-  const { as = 'a', className, asChild, ...restProps } = props
+const AlertLink = forwardRef<ElementRef<'a'>, AlertLinkProps>((props, ref) => {
+  const { className, asChild, ...restProps } = props
   const { layout, scheme, size } = useAlertContext()
-  const Component = asChild ? Slot : as
+  const Component = asChild ? Slot : 'a'
 
   return (
     <Component
@@ -33,7 +27,7 @@ const AlertLink = forwardRef((props, ref) => {
       {...restProps}
     />
   )
-}) as PolymorphicAlertLink
+})
 AlertLink.displayName = 'AlertLink'
 
-export { AlertLink, type PolymorphicAlertLink, type AlertLinkProps }
+export { AlertLink, type AlertLinkProps }

--- a/packages/components/alert/src/alert-title.tsx
+++ b/packages/components/alert/src/alert-title.tsx
@@ -1,37 +1,33 @@
-import { ComponentPropsWithRef, forwardRef } from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 import { alert } from '@mochi-ui/theme'
 import { Slot } from '@radix-ui/react-slot'
 import { useAlertContext } from './context'
 
-type PolymorphicAlertTitle = Polymorphic.ForwardRefComponent<
-  'h3',
-  { asChild?: boolean }
->
+type AlertTitleProps = ComponentPropsWithoutRef<'h3'> & { asChild?: boolean }
 
-type AlertTitleProps = ComponentPropsWithRef<PolymorphicAlertTitle>
+const AlertTitle = forwardRef<ElementRef<'h3'>, AlertTitleProps>(
+  (props, ref) => {
+    const { className, asChild, ...restProps } = props
+    const { scheme, layout, size } = useAlertContext()
 
-const AlertTitle = forwardRef((props, ref) => {
-  const { as = 'h3', className, asChild, ...restProps } = props
-  const { scheme, layout, size } = useAlertContext()
-
-  const Component = asChild ? Slot : as
-  return (
-    <Component
-      data-scheme={scheme}
-      data-layout={layout}
-      data-size={size}
-      className={alert.alertTitleCva({
-        scheme,
-        layout,
-        size,
-        className,
-      })}
-      ref={ref}
-      {...restProps}
-    />
-  )
-}) as PolymorphicAlertTitle
+    const Component = asChild ? Slot : 'h3'
+    return (
+      <Component
+        data-scheme={scheme}
+        data-layout={layout}
+        data-size={size}
+        className={alert.alertTitleCva({
+          scheme,
+          layout,
+          size,
+          className,
+        })}
+        ref={ref}
+        {...restProps}
+      />
+    )
+  },
+)
 AlertTitle.displayName = 'AlertTitle'
 
-export { AlertTitle, type PolymorphicAlertTitle, type AlertTitleProps }
+export { AlertTitle, type AlertTitleProps }

--- a/packages/components/alert/src/alert.tsx
+++ b/packages/components/alert/src/alert.tsx
@@ -1,5 +1,6 @@
 import { alert } from '@mochi-ui/theme'
-import { useMemo, forwardRef } from 'react'
+import { useMemo, forwardRef, ComponentPropsWithoutRef } from 'react'
+import { Slot } from '@radix-ui/react-slot'
 import { AlertContext, AlertContextValue } from './context'
 
 const { alertCva } = alert
@@ -10,7 +11,8 @@ type AlertProps = Partial<AlertContextValue> & {
   shadow?: boolean
   outline?: boolean
   paddingSize?: 'default' | 'large'
-}
+  asChild?: boolean
+} & ComponentPropsWithoutRef<'div'>
 
 const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
   const {
@@ -21,8 +23,11 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
     paddingSize,
     shadow,
     className,
+    asChild,
     ...restProps
   } = props
+
+  const Component = asChild ? Slot : 'div'
 
   const contextValue = useMemo(
     () => ({
@@ -35,7 +40,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
 
   return (
     <AlertContext.Provider value={contextValue}>
-      <div
+      <Component
         ref={ref}
         className={alertCva({
           scheme,

--- a/packages/components/alert/stories/alert.stories.tsx
+++ b/packages/components/alert/stories/alert.stories.tsx
@@ -127,7 +127,9 @@ export const Colors: Story = {
                   </AlertDescription>
                 </AlertBody>
                 <AlertActionGroup>
-                  <AlertCancelButton>Confirm</AlertCancelButton>
+                  <AlertCancelButton asChild>
+                    <a href="/#">Cancel</a>
+                  </AlertCancelButton>
                   <AlertConfirmButton>Confirm</AlertConfirmButton>
                 </AlertActionGroup>
                 <AlertCloseButton />

--- a/packages/components/toast/package.json
+++ b/packages/components/toast/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@mochi-ui/alert": "workspace:*",
-    "@mochi-ui/polymorphic": "workspace:*",
     "@mochi-ui/theme": "workspace:*",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",

--- a/packages/components/toast/src/toast-body.tsx
+++ b/packages/components/toast/src/toast-body.tsx
@@ -1,15 +1,9 @@
-import {
-  AlertBodyProps,
-  AlertBody,
-  PolymorphicAlertBody,
-} from '@mochi-ui/alert'
+import { AlertBodyProps, AlertBody } from '@mochi-ui/alert'
 
 type ToastBodyProps = AlertBodyProps
-
-type PolymorphicToastBody = PolymorphicAlertBody
 
 const ToastBody = AlertBody
 ToastBody.displayName = 'ToastBody'
 
-export type { ToastBodyProps, PolymorphicToastBody }
+export type { ToastBodyProps }
 export { ToastBody }

--- a/packages/components/toast/src/toast-close.tsx
+++ b/packages/components/toast/src/toast-close.tsx
@@ -1,27 +1,21 @@
-import {
-  ComponentPropsWithRef,
-  ComponentPropsWithoutRef,
-  forwardRef,
-} from 'react'
+import { ElementRef, forwardRef } from 'react'
 import * as ToastPrimitive from '@radix-ui/react-toast'
 import { AlertCloseButton, AlertCloseButtonProps } from '@mochi-ui/alert'
-import * as Polymorphic from '@mochi-ui/polymorphic'
 
-type PolymorphicToastIconButton = Polymorphic.ForwardRefComponent<
-  'button',
-  AlertCloseButtonProps & ComponentPropsWithoutRef<typeof ToastPrimitive.Close>
->
-const ToastClose = forwardRef((props, ref) => {
+type ToastCloseProps = AlertCloseButtonProps
+
+const ToastClose = forwardRef<
+  ElementRef<typeof AlertCloseButton>,
+  ToastCloseProps
+>((props, ref) => {
   return (
     <ToastPrimitive.Close asChild>
       <AlertCloseButton {...props} ref={ref} />
     </ToastPrimitive.Close>
   )
-}) as PolymorphicToastIconButton
+})
 
 ToastClose.displayName = ToastPrimitive.Close.displayName
 
-type ToastCloseProps = ComponentPropsWithRef<PolymorphicToastIconButton>
-
 export { ToastClose }
-export type { PolymorphicToastIconButton, ToastCloseProps }
+export type { ToastCloseProps }

--- a/packages/components/toast/src/toast-description.tsx
+++ b/packages/components/toast/src/toast-description.tsx
@@ -1,26 +1,21 @@
 import * as ToastPrimitive from '@radix-ui/react-toast'
-import * as Polymorphic from '@mochi-ui/polymorphic'
-import { ComponentPropsWithRef, forwardRef } from 'react'
-import { AlertDescription } from '@mochi-ui/alert'
+import { ElementRef, forwardRef } from 'react'
+import { AlertDescription, AlertDescriptionProps } from '@mochi-ui/alert'
 
-type PolymorphicToastDescription = Polymorphic.ForwardRefComponent<
-  'p',
-  {
-    asChild?: boolean
-  }
->
+type ToastDescriptionProps = AlertDescriptionProps
 
-const ToastDescription = forwardRef((props, ref) => {
+const ToastDescription = forwardRef<
+  ElementRef<typeof AlertDescription>,
+  ToastDescriptionProps
+>((props, ref) => {
   return (
     <ToastPrimitive.Description asChild>
       <AlertDescription {...props} ref={ref} />
     </ToastPrimitive.Description>
   )
-}) as PolymorphicToastDescription
+})
 
 ToastDescription.displayName = 'ToastDescription'
 
-type ToastDescriptionProps = ComponentPropsWithRef<PolymorphicToastDescription>
-
 export { ToastDescription }
-export type { ToastDescriptionProps, PolymorphicToastDescription }
+export type { ToastDescriptionProps }

--- a/packages/components/toast/src/toast-icon.tsx
+++ b/packages/components/toast/src/toast-icon.tsx
@@ -1,9 +1,8 @@
-import { AlertIcon } from '@mochi-ui/alert'
-import { ComponentPropsWithRef } from 'react'
+import { AlertIcon, AlertIconProps } from '@mochi-ui/alert'
+
+type ToastIconProps = AlertIconProps
 
 const ToastIcon = AlertIcon
 ToastIcon.displayName = 'ToastIcon'
-
-type ToastIconProps = ComponentPropsWithRef<typeof ToastIcon>
 
 export { ToastIcon, type ToastIconProps }

--- a/packages/components/toast/src/toast-link.tsx
+++ b/packages/components/toast/src/toast-link.tsx
@@ -1,14 +1,9 @@
-import {
-  AlertLink,
-  AlertLinkProps,
-  PolymorphicAlertLink,
-} from '@mochi-ui/alert'
+import { AlertLink, AlertLinkProps } from '@mochi-ui/alert'
 
-type PolymorphicToastLink = PolymorphicAlertLink
 type ToastLinkProps = AlertLinkProps
 
 const ToastLink = AlertLink
 ToastLink.displayName = 'ToastConfirmButton'
 
 export { ToastLink }
-export type { ToastLinkProps, PolymorphicToastLink }
+export type { ToastLinkProps }

--- a/packages/components/toast/src/toast-title.tsx
+++ b/packages/components/toast/src/toast-title.tsx
@@ -1,22 +1,19 @@
-import {
-  AlertTitle,
-  AlertTitleProps,
-  PolymorphicAlertTitle,
-} from '@mochi-ui/alert'
+import { AlertTitle, AlertTitleProps } from '@mochi-ui/alert'
 import * as ToastPrimitive from '@radix-ui/react-toast'
-import { forwardRef } from 'react'
+import { ElementRef, forwardRef } from 'react'
 
-type PolymorphicToastTitle = PolymorphicAlertTitle
 type ToastTitleProps = AlertTitleProps
 
-const ToastTitle = forwardRef((props, ref) => {
-  return (
-    <ToastPrimitive.Title asChild>
-      <AlertTitle ref={ref} {...props} />
-    </ToastPrimitive.Title>
-  )
-}) as PolymorphicToastTitle
+const ToastTitle = forwardRef<ElementRef<typeof AlertTitle>, ToastTitleProps>(
+  (props, ref) => {
+    return (
+      <ToastPrimitive.Title asChild>
+        <AlertTitle ref={ref} {...props} />
+      </ToastPrimitive.Title>
+    )
+  },
+)
 
 ToastTitle.displayName = ToastPrimitive.Title.displayName
 
-export { ToastTitle, type ToastTitleProps, type PolymorphicToastTitle }
+export { ToastTitle, type ToastTitleProps }

--- a/packages/components/toast/src/toast.tsx
+++ b/packages/components/toast/src/toast.tsx
@@ -28,12 +28,21 @@ const ToastViewPort = forwardRef<ToastViewPortRef, ToastViewPortProps>(
 ToastViewPort.displayName = ToastPrimitive.Viewport.displayName
 
 const Toast = forwardRef<ToastRef, ToastProps>((props, ref) => {
-  const { className, scheme, size, children, fullWidth, ...restProps } = props
+  const {
+    className,
+    scheme,
+    size,
+    children,
+    fullWidth,
+    asChild,
+    ...restProps
+  } = props
   const alertProps: AlertProps = {
     className,
     scheme,
     size,
     children,
+    asChild,
   }
   return (
     <ToastPrimitive.Root

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,9 +482,6 @@ importers:
       '@mochi-ui/icons':
         specifier: workspace:*
         version: link:../../icons
-      '@mochi-ui/polymorphic':
-        specifier: workspace:*
-        version: link:../polymorphic
       '@mochi-ui/theme':
         specifier: workspace:*
         version: link:../../theme
@@ -1751,9 +1748,6 @@ importers:
       '@mochi-ui/alert':
         specifier: workspace:*
         version: link:../alert
-      '@mochi-ui/polymorphic':
-        specifier: workspace:*
-        version: link:../polymorphic
       '@mochi-ui/theme':
         specifier: workspace:*
         version: link:../../theme


### PR DESCRIPTION
- Migrate Alert component to support `asChild`, remove `as` props
- Update Toast, ActionBar to use new Alert type api