### PR TITLE
feat: migrate iconbutton to use asChild prop

### DIFF
--- a/.changeset/serious-cougars-care.md
+++ b/.changeset/serious-cougars-care.md
@@ -1,0 +1,6 @@
+---
+'@mochi-ui/icon-button': patch
+'@mochi-ui/core': patch
+---
+
+migrate to use asChild prop for polymorphic

--- a/packages/components/icon-button/package.json
+++ b/packages/components/icon-button/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@mochi-ui/icons": "workspace:*",
-    "@mochi-ui/polymorphic": "workspace:*",
     "@mochi-ui/theme": "workspace:*",
+    "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0"
   },
   "clean-package": "../../../clean-package.config.json"

--- a/packages/components/icon-button/src/icon-button.tsx
+++ b/packages/components/icon-button/src/icon-button.tsx
@@ -1,22 +1,18 @@
 import { iconButton, IconButtonStylesProps } from '@mochi-ui/theme'
-import React from 'react'
-import type * as Polymorphic from '@mochi-ui/polymorphic'
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react'
+import { Slot } from '@radix-ui/react-slot'
 
 const { iconButtonCva } = iconButton
 
 export type IconButtonProps = IconButtonStylesProps & {
   label: string
-}
+  asChild?: boolean
+} & ComponentPropsWithoutRef<'button'>
 
-type PolymorphicIconButton = Polymorphic.ForwardRefComponent<
-  'button',
-  IconButtonProps
->
-
-const IconButton = React.forwardRef(
+const IconButton = React.forwardRef<ElementRef<'button'>, IconButtonProps>(
   (
     {
-      as: Component = 'button',
+      asChild,
       children,
       variant,
       color,
@@ -28,6 +24,7 @@ const IconButton = React.forwardRef(
     },
     ref,
   ) => {
+    const Component = asChild ? Slot : 'button'
     return (
       <Component
         ref={ref}
@@ -40,7 +37,7 @@ const IconButton = React.forwardRef(
       </Component>
     )
   },
-) as PolymorphicIconButton
+)
 
 IconButton.displayName = 'IconButton'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,12 +956,12 @@ importers:
       '@mochi-ui/icons':
         specifier: workspace:*
         version: link:../../icons
-      '@mochi-ui/polymorphic':
-        specifier: workspace:*
-        version: link:../polymorphic
       '@mochi-ui/theme':
         specifier: workspace:*
         version: link:../../theme
+      '@radix-ui/react-slot':
+        specifier: ^1.0.2
+        version: 1.0.2(react@18.2.0)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -7279,6 +7279,19 @@ packages:
       '@types/react': 18.2.28
       react: 18.2.0
 
+  /@radix-ui/react-compose-refs@1.0.1(react@18.2.0):
+    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.7
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-context@1.0.1(@types/react@18.2.28)(react@18.2.0):
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
@@ -7919,6 +7932,20 @@ packages:
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.28)(react@18.2.0)
       '@types/react': 18.2.28
       react: 18.2.0
+
+  /@radix-ui/react-slot@1.0.2(react@18.2.0):
+    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.7
+      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
+      react: 18.2.0
+    dev: false
 
   /@radix-ui/react-switch@1.0.3(@types/react@18.2.28)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-mxm87F88HyHztsI7N+ZUmEoARGkC22YVW5CaC+Byc+HRpuvCrOBPTAnXgf+tZ/7i0Sg/eOePGdMhUKhPaQEqow==}


### PR DESCRIPTION
- Migrate to use `asChild` for IconButton component