### PR TITLE
fix: profile widget init balance loading

### DIFF
--- a/apps/mochi-web/components/Profile/ProfileWidget.tsx
+++ b/apps/mochi-web/components/Profile/ProfileWidget.tsx
@@ -55,8 +55,9 @@ const defaultChainMapping: Record<string, string> = {
 export const ProfileWidget = () => {
   const { me } = useProfileStore()
   const { data: info } = useFetchProfileGlobalInfo(me?.id)
-  const { data: { totalUsdAmount: total = 0, pnl = '0' } = {} } =
+  const { data: { totalUsdAmount: total = 0, pnl = '0' } = {}, isLoading } =
     useFetchTotalBalance(me?.id)
+  const isFetchingBalance = !me?.id || isLoading
   const { isFetchingWallets, wallets } = useWalletStore(
     useShallow((s) => ({
       isFetchingWallets: s.isFetching,
@@ -176,7 +177,9 @@ export const ProfileWidget = () => {
           </Badge>
         </div>
         <div className="text-right">
-          <Typography level="h5">{utils.formatUsdDigit(total)}</Typography>
+          <Typography level="h5">
+            {isFetchingBalance ? '$0.00' : utils.formatUsdDigit(total)}
+          </Typography>
           <div className="flex justify-end items-center">
             <ValueChange
               trend={pnl.startsWith('-') ? 'down' : 'up'}
@@ -189,9 +192,13 @@ export const ProfileWidget = () => {
               >
                 {utils.formatPercentDigit(Number.isNaN(Number(pnl)) ? 0 : pnl)}{' '}
                 (
-                {utils.formatUsdDigit(
-                  Number.isNaN(Number(pnl)) ? 0 : (Number(pnl) * total) / 100,
-                )}
+                {isFetchingBalance
+                  ? '$0.00'
+                  : utils.formatUsdDigit(
+                      Number.isNaN(Number(pnl))
+                        ? 0
+                        : (Number(pnl) * total) / 100,
+                    )}
                 )
               </Typography>
             </ValueChange>


### PR DESCRIPTION
**What does this PR do?**

- [ ] lúc loading-page nên chuyển total-balance về $0.00

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/6969182239

**Media (Loom or gif)**

https://github.com/consolelabs/mochi-ui/assets/44285614/5354b645-7af8-41c2-90bb-e23c1efb336f

