### PR TITLE
fix: update style sharelink title

### DIFF
--- a/apps/mochi-web/pages/changelog/[version].tsx
+++ b/apps/mochi-web/pages/changelog/[version].tsx
@@ -108,7 +108,7 @@ export default function Page(
         </div>
         <div className="flex gap-2.5 justify-between items-center mt-6">
           <div className="flex flex-col gap-2">
-            <Typography level="p7" className="uppercase text-text-disabled">
+            <Typography level="p7" className="uppercase" color="textDisabled">
               Share this release
             </Typography>
             <div className="flex gap-2 items-center">

--- a/packages/theme/src/components/typography.ts
+++ b/packages/theme/src/components/typography.ts
@@ -18,7 +18,7 @@ const typographyVariants = cva(['overflow-hidden'], {
       p4: 'text-base',
       p5: 'text-sm',
       p6: 'text-xs',
-      p7: 'text-xxxs',
+      p7: 'text-xxxs tracking-normal',
       inherit: 'text-inherit',
     },
     color: {


### PR DESCRIPTION
Fix share link title color, letter spacing

<img width="196" alt="image" src="https://github.com/consolelabs/mochi-ui/assets/88917321/0fca8c22-36fe-4374-b8c7-203500072598">
