### PR TITLE
fix: recap section font

### DIFF
--- a/apps/mochi-web/components/Profile/RecapSection.tsx
+++ b/apps/mochi-web/components/Profile/RecapSection.tsx
@@ -99,7 +99,7 @@ const UserSection = ({ type, statTx }: Props) => {
           name={statTx?.token?.symbol || ''}
         />
         <Typography level="h8">{statTx?.token?.symbol}</Typography>
-        <Typography level="p5">
+        <Typography level="p5" className="font-mono">
           {mochiUtils.formatUsdDigit(statTx?.usd_amount || 0)}
         </Typography>
         <Typography level="p5">{type === 'sent' ? 'to' : 'from'}</Typography>
@@ -136,7 +136,7 @@ const TokenSection = ({ type, statTx }: Props) => {
             name={statTx.token?.symbol || ''}
           />
           <div className="flex flex-wrap items-center">
-            <Typography level="h8" className="mr-2 font-mono">
+            <Typography level="h8" className="mr-2">
               {mochiUtils.formatDigit({
                 value: utils.formatUnits(
                   statTx.amount || 0,


### PR DESCRIPTION
**What does this PR do?**

- [ ] chỉnh chỗ Recap chỉ đổi converted value > IBM plex mono, còn lại đổi Inter

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/7027893553

**Media (Loom or gif)**

![image](https://github.com/consolelabs/mochi-ui/assets/44285614/562e5f5b-1955-4841-b88d-2a2dd9fd349d)
