### PR TITLE
fix: profile and notification dropdown

### DIFF
--- a/apps/mochi-web/components/NotificationList/index.tsx
+++ b/apps/mochi-web/components/NotificationList/index.tsx
@@ -147,7 +147,7 @@ const NotificationList = () => {
           )}
         </IconButton>
       </DropdownMenuTrigger>
-      <DropdownMenuContent sideOffset={10} className="!p-0 overflow-hidden">
+      <DropdownMenuContent sideOffset={14} className="!p-0 overflow-hidden">
         <div className="flex relative flex-col" style={{ width: 400 }}>
           <Tabs value={tabValue} className="relative z-20 bg-white-pure">
             <div className="flex justify-between items-center p-2 pr-4 border-b border-neutral-200">

--- a/apps/mochi-web/components/ProfileDropdown.tsx
+++ b/apps/mochi-web/components/ProfileDropdown.tsx
@@ -63,7 +63,7 @@ export default function ProfileDropdown({
         <DropdownMenuContent
           wrapperClassName="z-20"
           className="overflow-y-auto w-screen flex flex-col -mt-3 rounded-none h-[calc(100vh-56px)] lg:m-0 lg:block lg:w-auto lg:h-auto lg:rounded-lg lg:max-h-[calc(100dvh-100px)]"
-          sideOffset={20}
+          sideOffset={9}
           collisionPadding={{
             right: 32,
             bottom: 32,


### PR DESCRIPTION
**What does this PR do?**

- [ ] Make profile & notification dropdown away from topbar 2px

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/7027917230

**Media (Loom or gif)**

![image](https://github.com/consolelabs/mochi-ui/assets/44285614/d1c18f5f-1220-4780-85bf-4ee3cae8e02b)
![image](https://github.com/consolelabs/mochi-ui/assets/44285614/e7b78da4-01c1-4d5d-83b9-d6c9add0f7ff)

