### PR TITLE
fix: log table row click and empty state

### DIFF
--- a/.changeset/ninety-phones-run.md
+++ b/.changeset/ninety-phones-run.md
@@ -1,0 +1,5 @@
+---
+"@mochi-ui/table": minor
+---
+
+Fix table on row function

--- a/apps/mochi-web/components/app/detail/AppDetailApiCalls.tsx
+++ b/apps/mochi-web/components/app/detail/AppDetailApiCalls.tsx
@@ -109,6 +109,17 @@ export const AppDetailApiCalls = ({ profileId, appId }: Props) => {
             </pre>
           </div>
         )}
+        onRow={(record, index, row) => ({
+          onClick: row.getToggleExpandedHandler(),
+        })}
+        emptyContent={
+          <div className="h-[357.5px] flex flex-col items-center justify-center text-center space-y-1">
+            <Typography level="h7">No logs found</Typography>
+            <Typography level="p4">
+              Your app hasn&apos;t called API with the provided key.
+            </Typography>
+          </div>
+        }
       />
     </div>
   )

--- a/packages/components/table/src/table.tsx
+++ b/packages/components/table/src/table.tsx
@@ -27,6 +27,7 @@ export interface TableProps<T> {
   onRow?: (
     record: T,
     rowIndex: number,
+    row: Row<T>,
   ) => {
     onClick?: (event: React.MouseEvent<HTMLTableRowElement, MouseEvent>) => void
     onDoubleClick?: (
@@ -161,7 +162,7 @@ export default function Table<T extends RowData>({
                       clickable: !!onRow,
                       className: rowClassName?.(row.original, rowIndex),
                     })}
-                    {...(onRow ? onRow(row.original, rowIndex) : {})}
+                    {...(onRow ? onRow(row.original, rowIndex, row) : {})}
                   >
                     {row.getVisibleCells().map((cell, colIndex) => (
                       <td


### PR DESCRIPTION
**What does this PR do?**

- [ ] log table: expand row instead of open link
- [ ] log table: add empty state

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/6929435955
- https://3.basecamp.com/4108948/buckets/34574984/todos/7001483248

**Media (Loom or gif)**

![image](https://github.com/consolelabs/mochi-ui/assets/44285614/c9c55076-071d-462f-accd-ca085e4546f8)

