### PR TITLE
fix: recap vault name

### DIFF
--- a/apps/mochi-web/components/Profile/RecapSection.tsx
+++ b/apps/mochi-web/components/Profile/RecapSection.tsx
@@ -44,7 +44,10 @@ interface Props {
 const UserSection = ({ type, statTx }: Props) => {
   const [profile] = UI.render(Platform.Web, statTx?.other_profile as Profile)
   const { theme } = useTheme()
-  const name = emojiStrip(profile?.plain || '').trim()
+  const name =
+    statTx?.other_profile?.type === 'vault'
+      ? statTx.other_profile.profile_name || 'Vault'
+      : emojiStrip(profile?.plain || '').trim()
   const icon =
     type === 'sent' ? (
       <TipSolid


### PR DESCRIPTION
**What does this PR do?**

- [ ] render vault name in the recap

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/7089814618
