### PR TITLE
fix: header color, sort chain by total asset, add extension download link

### DIFF
--- a/apps/mochi-web/components/Header/Header.tsx
+++ b/apps/mochi-web/components/Header/Header.tsx
@@ -389,11 +389,7 @@ export const Header = () => {
                 </Typography>
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="bg-white-pure"
-              sideOffset={20}
-              align="center"
-            >
+            <DropdownMenuContent sideOffset={20} align="center">
               <DropdownMenuItem
                 leftIcon={<CodingSolid />}
                 onClick={() => window.open(ROUTES.DOCS, '_blank')}
@@ -426,11 +422,7 @@ export const Header = () => {
                 </Typography>
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="bg-white-pure"
-              sideOffset={20}
-              align="center"
-            >
+            <DropdownMenuContent sideOffset={20} align="center">
               <DropdownMenuItem
                 leftIcon={<DiscordColored />}
                 onClick={() => window.open(DISCORD_LINK, '_blank')}
@@ -468,7 +460,7 @@ export const Header = () => {
             className="flex items-center -ml-4 w-px h-full"
             key="desktop-nav-divider"
           >
-            <div className="w-full h-6 bg-[#eeedec]" />
+            <div className="w-full h-6 bg-neutral-soft-active" />
           </div>,
           <IconButton
             label="dark/light mode toggle button"

--- a/apps/mochi-web/components/Profile/ProfileWidget.tsx
+++ b/apps/mochi-web/components/Profile/ProfileWidget.tsx
@@ -37,7 +37,7 @@ import { useFetchTotalBalance } from '~hooks/profile/useFetchTotalBalance'
 import { usePrevious } from '@dwarvesf/react-hooks'
 import { Token } from '@consolelabs/mochi-rest'
 
-const sortOrder = ['All', 'SOL', 'Mochi']
+const sortOrder = ['All', 'Mochi', 'SOL']
 const defaultChainMapping: Record<string, string> = {
   SOL: 'Solana',
   ETH: 'Ethereum',
@@ -159,9 +159,10 @@ export const ProfileWidget = () => {
       Mochi: balances.filter((b) => b.source.id === 'mochi'),
     },
   )
-  const sortedChains = Object.keys(chains)
-    .map((chain, index) => ({
+  const sortedChains = Object.entries(chains)
+    .map(([chain, balance], index) => ({
       chain,
+      totalAsset: balance.reduce((acc, c) => (acc += c.usd_balance), 0),
       index:
         index < displayChainAmount - 1
           ? displayChainAmount - index
@@ -171,7 +172,10 @@ export const ProfileWidget = () => {
       const indexA = sortOrder.findIndex((symbol) => symbol === a.chain)
       const indexB = sortOrder.findIndex((symbol) => symbol === b.chain)
 
-      if (indexA === -1 && indexB === -1) return b.index - a.index
+      // if not specified then compare by chain total asset
+      if (indexA === -1 && indexB === -1) {
+        return b.totalAsset - a.totalAsset
+      }
 
       if (indexA === -1) return 1
       if (indexB === -1) return -1

--- a/packages/web3/connect-wallet-widget/src/connect-wallet-widget.tsx
+++ b/packages/web3/connect-wallet-widget/src/connect-wallet-widget.tsx
@@ -188,7 +188,19 @@ const ConnectWalletWidget = forwardRef<
             )}
           </div>
           <Typography>
-            Download the wallet app:{' '}
+            Get the wallet:{' '}
+            <Button
+              variant="link"
+              className="!h-auto !p-0"
+              onClick={() =>
+                window.open(
+                  state.wallet?.metadata?.installUrl.extension,
+                  '_blank',
+                )
+              }
+            >
+              Extension
+            </Button>
             <Button
               variant="link"
               className="!h-auto !p-0"


### PR DESCRIPTION
**What does this PR do?**

- [x]  Header divider color by light/dark mode
- [x]  Sort profile chain tab by chain total asset
- [x]  Add extension download link when connecting wallet