### PR TITLE
fix: changelog title align center with button

### DIFF
--- a/apps/mochi-web/components/Changelog/ChangelogDetailTitle/ChangelogDetailTitle.tsx
+++ b/apps/mochi-web/components/Changelog/ChangelogDetailTitle/ChangelogDetailTitle.tsx
@@ -33,7 +33,7 @@ export const ChangelogDetailTitle = (props: ChangelogDetailTitleProps) => {
           </Typography>
         </div>
       </div>
-      <div className="flex gap-2 items-center">
+      <div className="flex gap-2 items-center min-h-[45px]">
         <Button asChild variant="outline" color="neutral" size="sm">
           <Link href={social} target="_blank">
             Follow @mochi_gg


### PR DESCRIPTION
**What does this PR do?**

- [ ] change log title align center with the button

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/7114796032

**Media (Loom or gif)**

![image](https://github.com/consolelabs/mochi-ui/assets/44285614/f42cbe64-750d-4fa9-ae79-b45f288be316)
