### PR TITLE
fix: mochi widget preview usd amount to token amount

### DIFF
--- a/apps/mochi-web/components/Amount.tsx
+++ b/apps/mochi-web/components/Amount.tsx
@@ -71,23 +71,25 @@ export default function Amount({
         'gap-y-1.5 grid-cols-1': isLongNumber,
       })}
     >
-      {isMoniker ? (
-        <div className="my-auto flex justify-center items-center w-7 h-7 rounded-full border border-[#E5E4E3]">
-          <span className="text-sm">{MonikerIcons.get(tokenIcon)}</span>
-        </div>
-      ) : (
-        <Avatar
-          size={size === 'lg' || size === 'md' ? 'xs' : 'xxs'}
-          className={clsx('shrink-0 aspect-square [&>img]:rounded-none', {
-            /* 'my-1': size === 'md' && alignment === 'center' && !isLongNumber, */
-            'row-start-1 row-span-2 my-auto':
-              alignment === 'left' && !isLongNumber,
-            'mx-auto': isLongNumber,
-          })}
-          src={tokenIcon || coinIcon.src}
-          smallSrc={platformIcon}
-        />
-      )}
+      <div className="h-8 flex items-center">
+        {isMoniker ? (
+          <div className="my-auto flex justify-center items-center w-7 h-7 rounded-full border border-[#E5E4E3]">
+            <span className="text-sm">{MonikerIcons.get(tokenIcon)}</span>
+          </div>
+        ) : (
+          <Avatar
+            size={size === 'lg' || size === 'md' ? 'xs' : 'xxs'}
+            className={clsx('shrink-0 aspect-square [&>img]:rounded-none', {
+              /* 'my-1': size === 'md' && alignment === 'center' && !isLongNumber, */
+              'row-start-1 row-span-2 my-auto':
+                alignment === 'left' && !isLongNumber,
+              'mx-auto': isLongNumber,
+            })}
+            src={tokenIcon || coinIcon.src}
+            smallSrc={platformIcon}
+          />
+        )}
+      </div>
       <div
         className={clsx('flex gap-x-1 items-center', {
           'flex-col items-center': isLongNumber,

--- a/apps/mochi-web/components/MochiWidget/TransactionPreview/TransactionPreview.tsx
+++ b/apps/mochi-web/components/MochiWidget/TransactionPreview/TransactionPreview.tsx
@@ -11,7 +11,9 @@ import {
 import { useProfileStore } from '~store'
 import UI, { Platform } from '@consolelabs/mochi-formatter'
 import stripEmoji from 'emoji-strip'
+import { formatTokenAmount } from '~utils/number'
 import { useTipWidget } from '../Tip/store'
+import { isToken } from '../TokenPicker/utils'
 
 function Recipient({
   children,
@@ -55,7 +57,7 @@ function Recipient({
 
 function TipPreview() {
   const { me } = useProfileStore()
-  const { wallet, request, amountUsd } = useTipWidget()
+  const { wallet, request } = useTipWidget()
 
   const receivers = useMemo(() => {
     if (!request.recipients) return null
@@ -120,7 +122,12 @@ function TipPreview() {
           )}
         </div>
         <span>They will receive</span>
-        <span className="text-right">{amountUsd} USD</span>
+        <span className="text-right">
+          {formatTokenAmount(request.amount ?? 0).display}{' '}
+          {isToken(request.asset)
+            ? request.asset?.token?.symbol ?? ''
+            : request.asset?.name ?? ''}
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
**What does this PR do?**

- [ ] preview: phần they will receive đổi thành token amount

**Related Ticket(s)**

- https://3.basecamp.com/4108948/buckets/34574984/todos/7090682508

**Media (Loom or gif)**

![image](https://github.com/consolelabs/mochi-ui/assets/44285614/0c8d7944-4651-4320-b4b0-260b2faf0d95)

